### PR TITLE
Add vertical turbulence scheme (Visser 1997) and 2D parameter handling + bug correction 

### DIFF
--- a/TrackMPD_Toolbox/Dispersion/HTurb20.m
+++ b/TrackMPD_Toolbox/Dispersion/HTurb20.m
@@ -55,8 +55,8 @@ devY=2*rand(n,1)-1;     % the random deviate in the Y direction
 
 % Apply random walk model to calculate horizontal turbulent particle
 % displacement
-TurbHx= devX.*sqrt(2*Kh*dt);
-TurbHy= devY.*sqrt(2*Kh*dt);
+TurbHx= sqrt(3)*devX.*sqrt(2*Kh*dt);
+TurbHy= sqrt(3)*devY.*sqrt(2*Kh*dt);
 
 varargout{1} = TurbHx;
 varargout{2} = TurbHy;

--- a/TrackMPD_Toolbox/Dispersion/HTurb30.m
+++ b/TrackMPD_Toolbox/Dispersion/HTurb30.m
@@ -55,9 +55,9 @@ devZ=2*rand(n,1)-1;     % the random deviate in the Z direction
 
 % Apply random walk model to calculate horizontal turbulent particle
 % displacement
-TurbHx= devX.*sqrt(2*Kh*dt);
-TurbHy= devY.*sqrt(2*Kh*dt);
-TurbV= devZ.*sqrt(2*Kv*dt);
+TurbHx= sqrt(3)*devX.*sqrt(2*Kh*dt);
+TurbHy= sqrt(3)*devY.*sqrt(2*Kh*dt);
+TurbV= sqrt(3)*devZ.*sqrt(2*Kv*dt);
 
 varargout{1} = TurbHx;
 varargout{2} = TurbHy;

--- a/TrackMPD_Toolbox/Dispersion/HTurb_drw3D.m
+++ b/TrackMPD_Toolbox/Dispersion/HTurb_drw3D.m
@@ -31,15 +31,15 @@ devZ=2*rand(1,1)-1;     % the random deviate in the Z direction
 
 % Compute particle displacement (extended diffusion equation)
 TurbHx = (dKh_dX)*dt + ... % dKp/dX term in the original equation
-           devX .* ... % Random walk component
+           sqrt(3)*devX .* ... % Random walk component
            (sqrt(2 * Kh_shiftx * dt));
 
 TurbHy= (dKh_dY)*dt + ... % dKp/dY term in the original equation
-           devY .* ... % Random walk component
+           sqrt(3)*devY .* ... % Random walk component
            (sqrt(2 * Kh_shifty * dt));
 
 TurbV= (dKv_dZ)*dt + ... % dKp/dZ term in the original equation
-           devZ .* ... % Random walk component
+           sqrt(3)*devZ .* ... % Random walk component
            (sqrt(2 * Kv_shiftz * dt));
 
 end

--- a/TrackMPD_Toolbox/Dispersion/HTurb_drw3D.m
+++ b/TrackMPD_Toolbox/Dispersion/HTurb_drw3D.m
@@ -1,0 +1,45 @@
+function [TurbHx,TurbHy,TurbV] = HTurb_drw3D(dt,Kh_shiftx,Kh_shifty,Kv_shiftz,dKh_dX, dKh_dY, dKv_dZ)
+% ============================================================================
+% $RCSfile$
+% $Source$
+% $Revision$
+% $Date$
+% $Author$
+% $Name$
+%
+% USAGE: [TurbHx,TurbHy,TurbV]=HTurb_drw3D(dt,Kh_shiftx,Kh_shifty,Kv_shiftz,dKh_dX,dKh_dY,dKv_dZ)
+% DESCRIPTION: 
+%
+% References:Visser, Andy. (1997). Using random walk models to simulate the vertical distribution of particles in a turbulent water column.
+% Marine Ecology-progress Series - MAR ECOL-PROGR SER. 158. 275-281. 10.3354/meps158275. 
+% 
+% Pilechi, A., Mohammadian, A., and Murphy, E.: A numerical framework for modeling fate and transport of microplastics in inland and
+% coastal waters, Marine P ollution Bulletin, 184, 114 119, 2022.
+% 
+% ============================================================================
+
+% Apply Random Walk Model
+% default options
+
+devX=2*rand(1,1)-1;     % the random deviate in the X direction
+devY=2*rand(1,1)-1;     % the random deviate in the Y direction
+devZ=2*rand(1,1)-1;     % the random deviate in the Z direction
+
+% Apply the diffusive random walk model to calculate horizontal and vertical turbulent 
+% particle  displacement
+
+
+% Compute particle displacement (extended diffusion equation)
+TurbHx = (dKh_dX)*dt + ... % dKp/dX term in the original equation
+           devX .* ... % Random walk component
+           (sqrt(2 * Kh_shiftx * dt));
+
+TurbHy= (dKh_dY)*dt + ... % dKp/dY term in the original equation
+           devY .* ... % Random walk component
+           (sqrt(2 * Kh_shifty * dt));
+
+TurbV= (dKv_dZ)*dt + ... % dKp/dZ term in the original equation
+           devZ .* ... % Random walk component
+           (sqrt(2 * Kv_shiftz * dt));
+
+end

--- a/TrackMPD_Toolbox/runTrackMPD/runTrackMPD.m
+++ b/TrackMPD_Toolbox/runTrackMPD/runTrackMPD.m
@@ -763,7 +763,7 @@ for k=1:numpartition % EXTERNAL LOOP
           else
             Behaviour = behaviour(conf.Beh,tspan,ReleaseTime); %IJR 0424
 			
-			% Floating particles don't come from the bed even in backward computation
+			% Floating particles don t come from the bed even in backward computation
             if Behaviour.Ws(jj)>0 && direction==-1
                 h_BEH = -Behaviour.Ws(jj)*(TimeStepCalc*24*60*60); % Ws (m/s) and TimeStepCalc (days) => h_BEH (m)
             else
@@ -886,7 +886,7 @@ for k=1:numpartition % EXTERNAL LOOP
               [LastUpPart,LastVpPart] = transformUScalar(LL1,LL2,LastUpPart,LastVpPart,conf.OGCM.Coordinates,-1); % convert to m/s
               TimeSettlingPart=tspan(end);     %IJR 24/02/24        
             else
-              LL3 = min([-Depth_partLonLat 0]); %min to avoid problems when interpolation near the coast
+              LL3 = min([-Depth_partLonLat, Surf_partLonLat]); 
             end
           end
         end              

--- a/TrackMPD_Toolbox/runTrackMPD/runTrackMPD.m
+++ b/TrackMPD_Toolbox/runTrackMPD/runTrackMPD.m
@@ -24,6 +24,26 @@ disp('running TrackMPD...')
 % Configuration
 conf=feval(conf_name);
 
+% Default values for 3D parameters not required in 2D
+if strcmpi(conf.Traj.Mode,'2D')
+  if ~isfield(conf.Traj,'KvOption')
+    conf.Traj.KvOption = 'none';
+  end
+  if ~isfield(conf.Traj,'Kv')
+    conf.Traj.Kv = 0.0;
+  end
+  if ~isfield(conf.Traj,'KhOption')
+    conf.Traj.KhOption = 'constant';
+  end
+  if ~isfield(conf.Traj,'Kh')
+    conf.Traj.Kh = 0.0;
+  end
+
+  if ~isfield(conf.OGCM,'VerticalLayer')
+    conf.OGCM.VerticalLayer = 'sigma2depthVar'; 
+  end
+end
+
 % Trajectory info
 ReleaseTime=conf.Traj.ReleaseTime; % Initial drifters release date
 
@@ -51,9 +71,13 @@ parfile = conf.Data.ParticlesFile;
 M = dlmread(parfile,',',0,0);
 par(:,pX)=M(:,1); % Create variable "par" with particles information
 par(:,pY)=M(:,2);
-par(:,pZ)=M(:,3);
 
 numpar=size(par,1);
+if strcmpi(conf.Traj.Mode,'3D')
+  par(:,pZ)=M(:,3);
+else
+  par(:,pZ)=zeros(numpar,1);
+end
 disp(['Number of particles = ' num2str(numpar) ' ; Release Time = ' datestr(ReleaseTime,'dd-mmm-yyyy HH:MM') ' ; ' conf.Traj.Direction ' trajectory']);
 
 % Parallel pool management
@@ -65,7 +89,7 @@ if mod(numpar,conf.Traj.NbCores) > 0
   disp(['Warning : The number of particles is not a multiple of conf.Traj.NbCores, it is not optimal !'])
 end
 if conf.Traj.NbCores > maxNumCompThreads('automatic')
-  disp(['Warning : conf.Traj.NbCores > Number of cores on the machine (' num2str(NbCores) '), NbCores is reduced accordingly:'])
+  disp(['Warning : conf.Traj.NbCores > Number of cores on the machine (' num2str(maxNumCompThreads('automatic')) '), NbCores is reduced accordingly.'])
   conf.Traj.NbCores = maxNumCompThreads('automatic');
 end
 disp(['conf.Traj.NbCores: ' num2str(conf.Traj.NbCores)])
@@ -431,7 +455,7 @@ for k=1:numpartition % EXTERNAL LOOP
       end
     end
     if strcmpi(conf.Traj.KvOption,'fromOGCM')
-      Kvsh=squeeze(KV(:,:,end-1,:)); % Kv at last layer  => Voir s'il faut aussi aller chercher à Layer
+      Kvsh=squeeze(KV(:,:,end-1,:)); % Kv at last layer
     else
       Kvsh=conf.Traj.Kv; % Kv at last layer   
     end
@@ -707,7 +731,13 @@ for k=1:numpartition % EXTERNAL LOOP
       %   disp(['Ind2 : ' num2str(Ind2)])
       TimeInd = Ind1(1):Ind2(1);
       TTs = TT(TimeInd);  
-       
+
+      % Vertical eddy diffusivity gradient dKv/dZ
+      % Computed once per external time step (does not depend on jj nor on particle position)
+      if strcmpi(conf.Traj.KvOption,'fromOGCM')
+        dK = zeros(size(KV(:,:,:,TimeInd)));
+        dK(:,:,2:end,:) = diff(KV(:,:,:,TimeInd),1,3) ./ diff(Depth(:,:,:,TimeInd),1,3);
+      end
 
       % Particle in water => Advection and turbulence computation
       if FateTypePart==0
@@ -731,19 +761,29 @@ for k=1:numpartition % EXTERNAL LOOP
            end
          end
           
-          % Turbulence
-          if strcmpi(conf.Traj.KhOption,'fromOGCM')
-            kh=interpTrackMPD(longitude,latitude,Depth(:,:,:,TimeInd),TTs,KH(:,:,:,TimeInd),[LL1 LL2 LL3],tspan(jj),mask_water); 
-          else
-            kh=conf.Traj.Kh;
-          end
-          if strcmpi(conf.Traj.KvOption,'fromOGCM')
-            kv=interpTrackMPD(longitude,latitude,Depth(:,:,:,TimeInd),TTs,KV(:,:,:,TimeInd),[LL1 LL2 LL3],tspan(jj),mask_water); 
-          else
-            kv=conf.Traj.Kv;
-          end
+          dt_s = TimeStepCalc*24*60*60; % timestep in seconds
 
-          [TurbHx, TurbHy, TurbV] = HTurb30(1,TimeStepCalc*24*60*60,'Kh',kh,'Kv',kv);
+          % Horizontal turbulence : random walk naive
+          if strcmpi(conf.Traj.KhOption,'fromOGCM')
+            kh = interpTrackMPD(longitude,latitude,Depth(:,:,:,TimeInd),TTs,KH(:,:,:,TimeInd),[LL1 LL2 LL3],tspan(jj),mask_water);
+          else
+            kh = conf.Traj.Kh;
+          end
+          [TurbHx, TurbHy, ~] = HTurb30(1, dt_s, 'Kh', kh, 'Kv', 0.0);
+
+          % Vertical turbulence : random walk Visser with correction of Kv gradient
+
+          if strcmpi(conf.Traj.KvOption,'fromOGCM')
+            % Gradient dKv/dZ
+            dKv_dZ = interpTrackMPD(longitude,latitude,Depth(:,:,:,TimeInd),TTs,dK,[LL1 LL2 LL3],tspan(jj),mask_water);
+            %Kv evaluated at the shifted position (correction of Visser)
+            Kv_shiftz = interpTrackMPD(longitude,latitude,Depth(:,:,:,TimeInd),TTs,KV(:,:,:,TimeInd),...
+                          [LL1 LL2 LL3+0.5*dKv_dZ*dt_s],tspan(jj),mask_water);
+          else
+            dKv_dZ  = 0.0;
+            Kv_shiftz = conf.Traj.Kv;
+          end
+          [~, ~, TurbV] = HTurb_drw3D(dt_s, 0.0, 0.0, Kv_shiftz, 0.0, 0.0, dKv_dZ);
 
           if ~strcmpi(conf.OGCM.Coordinates,'cartesian')
             dlnTur=cosd(LL2)*(TurbHx/1000)/6371*180/pi; % VM 2024/04/05
@@ -886,7 +926,7 @@ for k=1:numpartition % EXTERNAL LOOP
               [LastUpPart,LastVpPart] = transformUScalar(LL1,LL2,LastUpPart,LastVpPart,conf.OGCM.Coordinates,-1); % convert to m/s
               TimeSettlingPart=tspan(end);     %IJR 24/02/24        
             else
-              LL3 = min([-Depth_partLonLat, Surf_partLonLat]); 
+              LL3 = min([-Depth_partLonLat, Surf_partLonLat]);
             end
           end
         end              
@@ -959,7 +999,7 @@ for k=1:numpartition % EXTERNAL LOOP
   TRAJ.Lat = lt;
   TRAJ.Depth = h;
   
-  TRAJ.TimeStamp = ts_Tot_Output(1,:); %Time %IJR22 (avant ts_Tot_Output(:)')
+  TRAJ.TimeStamp = ts_Tot_Output(1,:); %Time
   TRAJ.InitialLonLatDepth = [TRAJ.Lon(:,1), TRAJ.Lat(:,1) TRAJ.Depth(:,1)]; %initial position
   TRAJ.FinalLonLatDepth(:,1) = TRAJ.Lon(:,end); %final position
   TRAJ.FinalLonLatDepth(:,2) = TRAJ.Lat(:,end);
@@ -1084,8 +1124,11 @@ TRAJ.OutDomainParticles=length(find(strcmpi(TRAJ.FateType,'OutDomain')));
 
 % Other metadata
 TRAJ.conf = conf;
-Behaviour = behaviour(conf.Beh,TRAJ.TimeStamp,ReleaseTime); %IJR Feb24
-TRAJ.conf.Beh= Behaviour; %IJR Feb24
+if strcmpi(conf.Traj.Mode,'3D')
+    % Only in 3D
+    Behaviour = behaviour(conf.Beh,TRAJ.TimeStamp,ReleaseTime); 
+    TRAJ.conf.Beh= Behaviour; 
+end
 
 % Not needed because MaskWater used instead
 %TRAJ.Domain.x=xland;


### PR DESCRIPTION
### Summary :
This PR adds a vertical random walk scheme based on Visser (1997), lets TrackMPD run in 2D without requiring 3D-only parameters, and fixes two bugs (diffusivity scaling and deposition when the bed is above z=0).

### Changes :

- New function HTurb_drw3D (Dispersion/): vertical random walk with the advective correction term, evaluating Kv at the displaced position via the local dKv/dZ gradient (Visser 1997; Pilechi et al. 2022).

- runTrackMPD: applies default values for KvOption, Kv, KhOption, Kh and VerticalLayer when Mode = '2D', so 3D parameters no longer need to be present in the config file for 2D runs. The dKv/dZ gradient is computed once per external time step rather than inside the inner particle loop.

- **Fix (turbulence)** Fixed the vertical diffusivity scaling in HTurb files : the uniform random deviate (variance 1/3) was scaled by sqrt(2·Kv·dt) without the variance-correction factor, underestimating vertical diffusion by a factor of 3. Added the sqrt(3) as a variance-correction factor.

<img width="413" height="342" alt="TURB_VERIF_COMP" src="https://github.com/user-attachments/assets/9b13c518-fe54-470e-a791-4f8f40d271e6" />


- Fix (deposition): when the bed is above z=0 (e.g. intertidal areas at high elevation), a non-deposited particle reaching the bed was clamped with min([-Depth_partLonLat 0]), which forced it to z=0 (below the bed) instead of onto the bed. Replaced with min([-Depth_partLonLat, Surf_partLonLat]) so the particle is bounded by the real bed and surface elevations.